### PR TITLE
Implémentation de la fonctionnalité -session avec mention des résidents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const { Client, GatewayIntentBits } = require('discord.js');
+const sessionCommand = require('./sessionCommand'); // Import de la commande session
 
-// Remplacez par votre token de bot
 const TOKEN = process.env.DISCORD_TOKEN; // Charge le token depuis les variables d'environnement
 const PREFIX = '-'; // Préfixe pour les commandes
 
@@ -25,6 +25,7 @@ client.on('messageCreate', async (message) => {
   console.log(`Auteur : ${message.author.tag}`);
   console.log(`Contenu brut : "${message.content}"`);
   console.log(`Type : ${message.type}`);
+  
   // Ignorer les messages du bot lui-même
   if (message.author.bot) return;
 
@@ -34,6 +35,18 @@ client.on('messageCreate', async (message) => {
   // Divise le message en commande et arguments
   const args = message.content.slice(PREFIX.length).trim().split(/ +/);
   const command = args.shift().toLowerCase();
+
+   // Commande 'session'
+   if (command === 'session') {
+    // Supprime le message contenant la commande
+    try {
+      await message.delete(); // Cette ligne supprime le message contenant la commande
+      // Après la suppression, le message est déjà traité, donc la commande est exécutée ici
+      return sessionCommand.execute(message); // Exécute la commande
+    } catch (error) {
+      console.error("Erreur lors de la suppression du message : ", error);
+    }
+  }
 
   // Commande 'accepter'
   if (command === 'accepter') {
@@ -90,7 +103,37 @@ A bientôt en RP sur **${message.guild.name}**.`
       message.reply("Une erreur est survenue lors de l'attribution des rôles.");
     }
   }
+
+  // Commande 'session' - Appel de la nouvelle fonctionnalité
+  if (command === 'session') {
+    sessionCommand.execute(message);
+  }
 });
+
+// Ajoutez cette commande pour tester la récupération des rôles
+client.on('messageCreate', async (message) => {
+  if (message.content === '-testRoles') {
+    const roleResident = message.guild.roles.cache.find(role => role.name === '🏠| Résident');
+    if (!roleResident) {
+      return message.reply('Le rôle "🏠| Résident" est introuvable sur ce serveur.');
+    }
+
+    // Liste des membres avec le rôle
+    const membersWithRole = message.guild.members.cache.filter(member => member.roles.cache.has(roleResident.id));
+
+    if (membersWithRole.size === 0) {
+      return message.reply('Aucun membre avec le rôle "🏠| Résident" trouvé.');
+    }
+
+    let response = 'Membres avec le rôle "🏠| Résident" :\n';
+    membersWithRole.forEach(member => {
+      response += `${member.user.tag}\n`;
+    });
+
+    message.reply(response);
+  }
+});
+
 
 // Connexion du bot
 client.login(TOKEN);

--- a/sessionCommand.js
+++ b/sessionCommand.js
@@ -1,0 +1,34 @@
+module.exports = {
+    name: 'session',
+    description: 'Lance une session avec un message automatique dans le salon.',
+    async execute(message) {
+      // Vérifie si le rôle "🏠| Résident" existe
+      const roleResident = message.guild.roles.cache.find(role => role.name === '🏠| Résident');
+      if (!roleResident) {
+        return message.reply('Le rôle "🏠| Résident" est introuvable sur ce serveur.');
+      }
+  
+      // Mentionne tous les membres avec le rôle "🏠| Résident"
+      try {
+        await message.channel.send(`
+          **Lancement de session**
+  
+          La session est en cours de lancement,   
+          Veuillez vous préparer et attendre le message de lancement. 
+  
+          N'oubliez pas : 
+          ° Retirer vos cartes de compétences
+          ° Retirer la visée automatique
+          ° Mettre la boussole 
+          ° Vérifier que votre chat vocal est bien actif
+          ° Retirer le nom au dessus des joueurs
+  
+          ${roleResident.toString()}  
+        `);
+      } catch (error) {
+        console.error(error);
+        message.reply('Une erreur est survenue lors de l\'envoi du message de session.');
+      }
+    }
+  };
+  


### PR DESCRIPTION
Ajout de la commande -session pour lancer une session avec un message contenant des informations importantes pour les résidents. La commande mentionne également tous les utilisateurs ayant le rôle "🏠| Résident" afin de les notifier.

Modifications :
Création de la commande -session qui envoie un message dans le canal où elle a été exécutée.
La commande mentionne tous les utilisateurs ayant le rôle "🏠| Résident".
La commande supprime le texte -session du message initial, pour éviter la répétition.
Comportement attendu :
Lorsque l'utilisateur tape -session, la commande vérifie que l'utilisateur a le rôle "🏠| Résident" avant de l'exécuter.
Un message est envoyé dans le canal mentionnant tous les résidents.
Le bot ne mentionne que le rôle "🏠| Résident", sans afficher les noms des utilisateurs.
Instructions de test :
Dans un serveur Discord avec des utilisateurs ayant le rôle "🏠| Résident".
Tapez la commande -session dans un canal où le bot peut répondre.
Vérifiez que :
Un message est envoyé mentionnant le rôle "🏠| Résident".
Aucun nom d'utilisateur spécifique n'est mentionné.
Autres informations :
Aucune dépendance supplémentaire.
Vérifier que le bot a les bonnes permissions pour envoyer des messages et mentionner les rôles.